### PR TITLE
Use excludes instead of exclude in ES _source query

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -287,7 +287,7 @@ export default class Job extends events.EventEmitter {
     const nowTime = moment().toISOString();
     const query = {
       _source : {
-        exclude: [ 'output.content' ]
+        excludes: [ 'output.content' ]
       },
       query: {
         constant_score: {

--- a/test/src/worker.js
+++ b/test/src/worker.js
@@ -278,7 +278,7 @@ describe('Worker class', function () {
         const excludedFields = [ 'output.content' ];
         const { body } = getSearchParams(jobtype);
         expect(body).to.have.property('_source');
-        expect(body._source).to.eql({ exclude: excludedFields });
+        expect(body._source).to.eql({ excludes: excludedFields });
       });
 
       it('should search by job type', function () {


### PR DESCRIPTION
As of ES 5.0, you must use the plural name.

The tests are failing for me locally on master and this branch,
but they are failing in the same way in both places at least.